### PR TITLE
Rename pushdCurrentDirectory option to doNotPushdCurrentDirectory

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Documentation
     * [.executeSync(command, [options])](#module_elevator.executeSync) ⇒ <code>String</code>
 
 <a name="module_elevator.execute"></a>
+
 ### elevator.execute(command, [options], callback)
 **Kind**: static method of <code>[elevator](#module_elevator)</code>  
 **Summary**: Execute a command with UAC elevation  
@@ -47,7 +48,7 @@ Documentation
 | [options] | <code>Object</code> | <code>{}</code> | options |
 | [options.terminating] | <code>Boolean</code> |  | Launches a terminating command processor; equivalent to "cmd /c command". |
 | [options.persistent] | <code>Boolean</code> |  | Launches a persistent command processor; equivalent to "cmd /k command". |
-| [options.pushdCurrentDirectory] | <code>Boolean</code> |  | When using -c or -k, do not pushd the current directory before execution. |
+| [options.doNotPushdCurrentDirectory] | <code>Boolean</code> |  | When using -c or -k, do not pushd the current directory before execution. |
 | [options.unicode] | <code>Boolean</code> |  | When using -c or -k, use Unicode; equivalent to "cmd /u". |
 | [options.waitForTermination] | <code>Boolean</code> |  | Waits for termination; equivalent to "start /wait command". |
 | callback | <code>function</code> |  | callback (error, stdout, stderr) |
@@ -66,6 +67,7 @@ elevator.execute([ 'cmd.exe' ], {
 });
 ```
 <a name="module_elevator.executeSync"></a>
+
 ### elevator.executeSync(command, [options]) ⇒ <code>String</code>
 **Kind**: static method of <code>[elevator](#module_elevator)</code>  
 **Summary**: Execute a command with UAC elevation (Sync)  
@@ -78,7 +80,7 @@ elevator.execute([ 'cmd.exe' ], {
 | [options] | <code>Object</code> | <code>{}</code> | options |
 | [options.terminating] | <code>Boolean</code> |  | Launches a terminating command processor; equivalent to "cmd /c command". |
 | [options.persistent] | <code>Boolean</code> |  | Launches a persistent command processor; equivalent to "cmd /k command". |
-| [options.pushdCurrentDirectory] | <code>Boolean</code> |  | When using -c or -k, do not pushd the current directory before execution. |
+| [options.doNotPushdCurrentDirectory] | <code>Boolean</code> |  | When using -c or -k, do not pushd the current directory before execution. |
 | [options.unicode] | <code>Boolean</code> |  | When using -c or -k, use Unicode; equivalent to "cmd /u". |
 | [options.waitForTermination] | <code>Boolean</code> |  | Waits for termination; equivalent to "start /wait command". |
 

--- a/lib/command.js
+++ b/lib/command.js
@@ -58,7 +58,7 @@ exports.getBinaryPath = function() {
  * @param {Object} [options={}] - options
  * @param {Boolean} [options.terminating] - Launches a terminating command processor; equivalent to "cmd /c command".
  * @param {Boolean} [options.persistent] - Launches a persistent command processor; equivalent to "cmd /k command".
- * @param {Boolean} [options.pushdCurrentDirectory] - When using -c or -k, do not pushd the current directory before execution.
+ * @param {Boolean} [options.doNotPushdCurrentDirectory] - When using -c or -k, do not pushd the current directory before execution.
  * @param {Boolean} [options.unicode] - When using -c or -k, use Unicode; equivalent to "cmd /u".
  * @param {Boolean} [options.waitForTermination] - Waits for termination; equivalent to "start /wait command".
  *
@@ -81,8 +81,8 @@ exports.build = function(command, options) {
     throw new Error('Can\'t have a both persistent and terminating command processor');
   }
 
-  if (options.pushdCurrentDirectory && !options.terminating && !options.persistent) {
-    throw new Error('pushdCurrentDirectory requires the terminating or persistent option');
+  if (options.doNotPushdCurrentDirectory && !options.terminating && !options.persistent) {
+    throw new Error('doNotPushdCurrentDirectory requires the terminating or persistent option');
   }
 
   if (options.unicode && !options.terminating && !options.persistent) {
@@ -99,7 +99,7 @@ exports.build = function(command, options) {
     args.push('-k');
   }
 
-  if (options.pushdCurrentDirectory) {
+  if (options.doNotPushdCurrentDirectory) {
     args.push('-n');
   }
 

--- a/lib/elevator.js
+++ b/lib/elevator.js
@@ -38,7 +38,7 @@ var commandBuilder = require('./command');
  * @param {Object} [options={}] - options
  * @param {Boolean} [options.terminating] - Launches a terminating command processor; equivalent to "cmd /c command".
  * @param {Boolean} [options.persistent] - Launches a persistent command processor; equivalent to "cmd /k command".
- * @param {Boolean} [options.pushdCurrentDirectory] - When using -c or -k, do not pushd the current directory before execution.
+ * @param {Boolean} [options.doNotPushdCurrentDirectory] - When using -c or -k, do not pushd the current directory before execution.
  * @param {Boolean} [options.unicode] - When using -c or -k, use Unicode; equivalent to "cmd /u".
  * @param {Boolean} [options.waitForTermination] - Waits for termination; equivalent to "start /wait command".
  * @param {Function} callback - callback (error, stdout, stderr)
@@ -70,7 +70,7 @@ exports.execute = function(command, options, callback) {
  * @param {Object} [options={}] - options
  * @param {Boolean} [options.terminating] - Launches a terminating command processor; equivalent to "cmd /c command".
  * @param {Boolean} [options.persistent] - Launches a persistent command processor; equivalent to "cmd /k command".
- * @param {Boolean} [options.pushdCurrentDirectory] - When using -c or -k, do not pushd the current directory before execution.
+ * @param {Boolean} [options.doNotPushdCurrentDirectory] - When using -c or -k, do not pushd the current directory before execution.
  * @param {Boolean} [options.unicode] - When using -c or -k, use Unicode; equivalent to "cmd /u".
  * @param {Boolean} [options.waitForTermination] - Waits for termination; equivalent to "start /wait command".
  * @returns {String} stdout buffer

--- a/tests/command.spec.js
+++ b/tests/command.spec.js
@@ -163,12 +163,12 @@ describe('Command', function() {
 
     });
 
-    describe('given terminating = true and pushdCurrentDirectory = true', function() {
+    describe('given terminating = true and doNotPushdCurrentDirectory = true', function() {
 
       it('should return the correct command', function() {
         var result = command.build([ 'foo' ], {
           terminating: true,
-          pushdCurrentDirectory: true
+          doNotPushdCurrentDirectory: true
         });
 
         m.chai.expect(result).to.deep.equal([ '-c', '-n', 'foo' ]);
@@ -176,12 +176,12 @@ describe('Command', function() {
 
     });
 
-    describe('given persistent = true and pushdCurrentDirectory = true', function() {
+    describe('given persistent = true and doNotPushdCurrentDirectory = true', function() {
 
       it('should return the correct command', function() {
         var result = command.build([ 'foo' ], {
           persistent: true,
-          pushdCurrentDirectory: true
+          doNotPushdCurrentDirectory: true
         });
 
         m.chai.expect(result).to.deep.equal([ '-k', '-n', 'foo' ]);
@@ -189,14 +189,14 @@ describe('Command', function() {
 
     });
 
-    describe('given only pushdCurrentDirectory = true', function() {
+    describe('given only doNotPushdCurrentDirectory = true', function() {
 
       it('should throw an error', function() {
         m.chai.expect(function() {
           command.build([ 'foo' ], {
-            pushdCurrentDirectory: true
+            doNotPushdCurrentDirectory: true
           });
-        }).to.throw('pushdCurrentDirectory requires the terminating or persistent option');
+        }).to.throw('doNotPushdCurrentDirectory requires the terminating or persistent option');
       });
 
     });


### PR DESCRIPTION
This is a subtle documentation error. According the `elevate.exe`, the
`-n` _prevents_ the current directory to be `pushd`.

Signed-off-by: Juan Cruz Viotti jviottidc@gmail.com
