### PR TITLE
Remove unnecessary `lodash` dependency

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -23,7 +23,6 @@
  */
 
 var os = require('os');
-var _ = require('lodash');
 var path = require('path');
 var binPath = path.join(__dirname, '..', 'bin');
 

--- a/package.json
+++ b/package.json
@@ -35,8 +35,5 @@
     "jsdoc-to-markdown": "^1.1.1",
     "jshint-stylish": "^2.0.1",
     "mochainon": "^1.0.0"
-  },
-  "dependencies": {
-    "lodash": "^3.10.1"
   }
 }


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti jviottidc@gmail.com
